### PR TITLE
patch glibc vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ ENV DB_USER admin
 ENV DB_PASS password
 ADD setup-database.sh /docker-entrypoint-initdb.d/
 #ADD docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod 755 /docker-entrypoint-initdb.d/setup-database.sh
-#
+RUN apt-get update && \
+    apt-get install -y libc-bin && \
+    apt-get install -y libc6 && \
+    chmod 755 /docker-entrypoint-initdb.d/setup-database.sh


### PR DESCRIPTION
In lieu of using the patched 9.4.6 as a base
