### PR TITLE
ADD DOCKER HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ ENV DB_NAME database
 ENV DB_USER admin
 ENV DB_PASS password
 COPY setup-database.sh /docker-entrypoint-initdb.d/
+COPY docker-healthcheck.sh /docker-healthcheck/
 #ADD docker-entrypoint.sh /docker-entrypoint.sh
 RUN apt-get update && \
     apt-get install -y libc-bin && \
     apt-get install -y libc6 && \
-    chmod 755 /docker-entrypoint-initdb.d/setup-database.sh
+    chmod 755 /docker-entrypoint-initdb.d/setup-database.sh && \
+    chmod 755 /docker-healthcheck/docker-healthcheck.sh
+HEALTHCHECK CMD ["/docker-healthcheck/docker-healthcheck.sh"]
+

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+user="${DB_USER:-admin}"
+db="${DB_NAME:-$DB_USER}"
+export PGPASSWORD="${DB_PASS:-}"
+
+args=(
+    # force postgres to not use the local unix socket (test "external" connectibility)
+    --host "$host"
+    --username "$user"
+    --dbname "$db"
+    --quiet --no-align --tuples-only
+)
+
+if select="$(echo 'SELECT 1' | psql "${args[@]}")" && [ "$select" = '1' ]; then
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
added a HEALTHCHECK script to the original docker file to check that the DB us up and running.  Trying to solve a race condition docker-compose to run sal and the postgres container - sal starts before the database is ready.